### PR TITLE
NS Scenario 1 Coupled Resources: recommendation for duplication of CR

### DIFF
--- a/proposals/JRC/ds-linking-simplification-good-practice.md
+++ b/proposals/JRC/ds-linking-simplification-good-practice.md
@@ -240,6 +240,13 @@ Regarding the definition of a Network Service metadata, two scenarios have been 
 | --- | --- |
 | A | The `xlink:href` attribute of each of the `srv:operatesOn` elements SHALL contain a URI pointing to the metadata record of the provided data set or data set series. |
 
+### Recommendation: \<srv:operatesOn\> element priority over \<wms:MetadataURL\> and \<wfs:MetadataURL\> elements
+
+| **Recommendation** | **/rec/coupled-resource-operateson-match-metadataurl** |
+| --- | --- |
+| A | Within the Scenario 1 implementation, the references described with these optional `metadataURL` elements should match each of the `srv:operatesOn` elements contained in the service metadata record. In case of discrepancies, the references expressed with `srv:operatesOn` prevail over the other associations. |
+
+
 ### 8.2.2 INSPIRE Network service - Scenario 2
 
  - In Scenario 2, the [INSPIRE NS - Download Service TG] maps all INSPIRE metadata elements to the applicable elements in the service (i.e. ATOM feed elements or OGC Capabilities), and for OGC services, it currently relies on the ExtendedCapabilities section for the remaining elements.  [Annex B](#annex-b), which is subject to future work proposes an approach for the revision of the mapping of the INSPIRE requirements with the aim to possibly remove the Extended Capabilities section.


### PR DESCRIPTION
Scenario1 publish a minimal amount of metadata within the service, limited to the language (or languages) supported by the service, together with a link to a Download Service metadata record (e.g. from a discovery service).
The MD TG requirement 3.6, focused on service metadata, specifies to provide links to the data set metadata using `srv:operatesOn`.

In case the data provider (or the service implementer) decides to incorporate the CoupledResources elements, as defined by Scenario2, duplication may occur, and therefore discrepancies.

This recommendation aim to resolve, with a declared prioritization, this issue.